### PR TITLE
First for review

### DIFF
--- a/aws/enforce_kms_key_names.mock.json
+++ b/aws/enforce_kms_key_names.mock.json
@@ -1,0 +1,1880 @@
+{
+    "mock": {
+      "s3_invalid": {
+        "tfplan": {
+          "format_version": "0.1",
+          "terraform_version": "0.12.28",
+          "planned_values": {
+            "outputs": {
+              "key": {
+                "sensitive": false,
+                "value": {
+                  "arn": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                  "aws_account_id": "670025224396",
+                  "creation_date": "2020-08-26T10:33:52Z",
+                  "customer_master_key_spec": "SYMMETRIC_DEFAULT",
+                  "deletion_date": null,
+                  "description": "",
+                  "enabled": true,
+                  "expiration_model": "",
+                  "grant_tokens": null,
+                  "id": "ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                  "key_id": "alias/pg-kms-key",
+                  "key_manager": "CUSTOMER",
+                  "key_state": "Enabled",
+                  "key_usage": "ENCRYPT_DECRYPT",
+                  "origin": "AWS_KMS",
+                  "valid_to": null
+                }
+              }
+            },
+            "root_module": {
+              "resources": [
+                {
+                  "address": "aws_s3_bucket.pg-kms-bucket-1",
+                  "mode": "managed",
+                  "type": "aws_s3_bucket",
+                  "name": "pg-kms-bucket-1",
+                  "provider_name": "aws",
+                  "schema_version": 0,
+                  "values": {
+                    "acl": "private",
+                    "bucket": "pg-kms-mybucket-1",
+                    "bucket_prefix": null,
+                    "cors_rule": [],
+                    "force_destroy": false,
+                    "grant": [],
+                    "lifecycle_rule": [],
+                    "logging": [],
+                    "object_lock_configuration": [],
+                    "policy": null,
+                    "replication_configuration": [],
+                    "server_side_encryption_configuration": [
+                      {
+                        "rule": [
+                          {
+                            "apply_server_side_encryption_by_default": [
+                              {
+                                "kms_master_key_id": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708ss",
+                                "sse_algorithm": "aws:kms"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ],
+                    "tags": null,
+                    "website": []
+                  }
+                },
+                {
+                  "address": "aws_s3_bucket.pg-kms-bucket-2",
+                  "mode": "managed",
+                  "type": "aws_s3_bucket",
+                  "name": "pg-kms-bucket-2",
+                  "provider_name": "aws",
+                  "schema_version": 0,
+                  "values": {
+                    "acl": "private",
+                    "bucket": "pg-kms-mybucket-2",
+                    "bucket_prefix": null,
+                    "cors_rule": [],
+                    "force_destroy": false,
+                    "grant": [],
+                    "lifecycle_rule": [],
+                    "logging": [],
+                    "object_lock_configuration": [],
+                    "policy": null,
+                    "replication_configuration": [
+                      {
+                        "role": "foo",
+                        "rules": [
+                          {
+                            "destination": [
+                              {
+                                "access_control_translation": [],
+                                "account_id": "",
+                                "replica_kms_key_id": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                                "storage_class": "STANDARD"
+                              }
+                            ],
+                            "filter": [],
+                            "id": "foobar",
+                            "prefix": "foo",
+                            "priority": null,
+                            "source_selection_criteria": [
+                              {
+                                "sse_kms_encrypted_objects": [
+                                  {
+                                    "enabled": true
+                                  }
+                                ]
+                              }
+                            ],
+                            "status": "Enabled"
+                          }
+                        ]
+                      }
+                    ],
+                    "server_side_encryption_configuration": [
+                      {
+                        "rule": [
+                          {
+                            "apply_server_side_encryption_by_default": [
+                              {
+                                "kms_master_key_id": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                                "sse_algorithm": "aws:kms"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ],
+                    "tags": null,
+                    "website": []
+                  }
+                },
+                {
+                  "address": "random_string.rs",
+                  "mode": "managed",
+                  "type": "random_string",
+                  "name": "rs",
+                  "provider_name": "random",
+                  "schema_version": 1,
+                  "values": {
+                    "keepers": null,
+                    "length": 6,
+                    "lower": true,
+                    "min_lower": 0,
+                    "min_numeric": 0,
+                    "min_special": 0,
+                    "min_upper": 0,
+                    "number": true,
+                    "override_special": null,
+                    "special": true,
+                    "upper": true
+                  }
+                }
+              ]
+            }
+          },
+          "resource_changes": [
+            {
+              "address": "aws_s3_bucket.pg-kms-bucket-1",
+              "mode": "managed",
+              "type": "aws_s3_bucket",
+              "name": "pg-kms-bucket-1",
+              "provider_name": "aws",
+              "change": {
+                "actions": [
+                  "create"
+                ],
+                "before": null,
+                "after": {
+                  "acl": "private",
+                  "bucket": "pg-kms-mybucket-1",
+                  "bucket_prefix": null,
+                  "cors_rule": [],
+                  "force_destroy": false,
+                  "grant": [],
+                  "lifecycle_rule": [],
+                  "logging": [],
+                  "object_lock_configuration": [],
+                  "policy": null,
+                  "replication_configuration": [],
+                  "server_side_encryption_configuration": [
+                    {
+                      "rule": [
+                        {
+                          "apply_server_side_encryption_by_default": [
+                            {
+                              "kms_master_key_id": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708ss",
+                              "sse_algorithm": "aws:kms"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "tags": null,
+                  "website": []
+                },
+                "after_unknown": {
+                  "acceleration_status": true,
+                  "arn": true,
+                  "bucket_domain_name": true,
+                  "bucket_regional_domain_name": true,
+                  "cors_rule": [],
+                  "grant": [],
+                  "hosted_zone_id": true,
+                  "id": true,
+                  "lifecycle_rule": [],
+                  "logging": [],
+                  "object_lock_configuration": [],
+                  "region": true,
+                  "replication_configuration": [],
+                  "request_payer": true,
+                  "server_side_encryption_configuration": [
+                    {
+                      "rule": [
+                        {
+                          "apply_server_side_encryption_by_default": [
+                            {}
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "versioning": true,
+                  "website": [],
+                  "website_domain": true,
+                  "website_endpoint": true
+                }
+              }
+            },
+            {
+              "address": "aws_s3_bucket.pg-kms-bucket-2",
+              "mode": "managed",
+              "type": "aws_s3_bucket",
+              "name": "pg-kms-bucket-2",
+              "provider_name": "aws",
+              "change": {
+                "actions": [
+                  "create"
+                ],
+                "before": null,
+                "after": {
+                  "acl": "private",
+                  "bucket": "pg-kms-mybucket-2",
+                  "bucket_prefix": null,
+                  "cors_rule": [],
+                  "force_destroy": false,
+                  "grant": [],
+                  "lifecycle_rule": [],
+                  "logging": [],
+                  "object_lock_configuration": [],
+                  "policy": null,
+                  "replication_configuration": [
+                    {
+                      "role": "foo",
+                      "rules": [
+                        {
+                          "destination": [
+                            {
+                              "access_control_translation": [],
+                              "account_id": "",
+                              "replica_kms_key_id": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                              "storage_class": "STANDARD"
+                            }
+                          ],
+                          "filter": [],
+                          "id": "foobar",
+                          "prefix": "foo",
+                          "priority": null,
+                          "source_selection_criteria": [
+                            {
+                              "sse_kms_encrypted_objects": [
+                                {
+                                  "enabled": true
+                                }
+                              ]
+                            }
+                          ],
+                          "status": "Enabled"
+                        }
+                      ]
+                    }
+                  ],
+                  "server_side_encryption_configuration": [
+                    {
+                      "rule": [
+                        {
+                          "apply_server_side_encryption_by_default": [
+                            {
+                              "kms_master_key_id": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                              "sse_algorithm": "aws:kms"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "tags": null,
+                  "website": []
+                },
+                "after_unknown": {
+                  "acceleration_status": true,
+                  "arn": true,
+                  "bucket_domain_name": true,
+                  "bucket_regional_domain_name": true,
+                  "cors_rule": [],
+                  "grant": [],
+                  "hosted_zone_id": true,
+                  "id": true,
+                  "lifecycle_rule": [],
+                  "logging": [],
+                  "object_lock_configuration": [],
+                  "region": true,
+                  "replication_configuration": [
+                    {
+                      "rules": [
+                        {
+                          "destination": [
+                            {
+                              "access_control_translation": [],
+                              "bucket": true
+                            }
+                          ],
+                          "filter": [],
+                          "source_selection_criteria": [
+                            {
+                              "sse_kms_encrypted_objects": [
+                                {}
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "request_payer": true,
+                  "server_side_encryption_configuration": [
+                    {
+                      "rule": [
+                        {
+                          "apply_server_side_encryption_by_default": [
+                            {}
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "versioning": true,
+                  "website": [],
+                  "website_domain": true,
+                  "website_endpoint": true
+                }
+              }
+            },
+            {
+              "address": "random_string.rs",
+              "mode": "managed",
+              "type": "random_string",
+              "name": "rs",
+              "provider_name": "random",
+              "change": {
+                "actions": [
+                  "create"
+                ],
+                "before": null,
+                "after": {
+                  "keepers": null,
+                  "length": 6,
+                  "lower": true,
+                  "min_lower": 0,
+                  "min_numeric": 0,
+                  "min_special": 0,
+                  "min_upper": 0,
+                  "number": true,
+                  "override_special": null,
+                  "special": true,
+                  "upper": true
+                },
+                "after_unknown": {
+                  "id": true,
+                  "result": true
+                }
+              }
+            }
+          ],
+          "output_changes": {
+            "key": {
+              "actions": [
+                "create"
+              ],
+              "before": null,
+              "after": {
+                "arn": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                "aws_account_id": "670025224396",
+                "creation_date": "2020-08-26T10:33:52Z",
+                "customer_master_key_spec": "SYMMETRIC_DEFAULT",
+                "deletion_date": null,
+                "description": "",
+                "enabled": true,
+                "expiration_model": "",
+                "grant_tokens": null,
+                "id": "ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                "key_id": "alias/pg-kms-key",
+                "key_manager": "CUSTOMER",
+                "key_state": "Enabled",
+                "key_usage": "ENCRYPT_DECRYPT",
+                "origin": "AWS_KMS",
+                "valid_to": null
+              },
+              "after_unknown": false
+            }
+          },
+          "prior_state": {
+            "format_version": "0.1",
+            "terraform_version": "0.12.28",
+            "values": {
+              "outputs": {
+                "key": {
+                  "sensitive": false,
+                  "value": {
+                    "arn": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                    "aws_account_id": "670025224396",
+                    "creation_date": "2020-08-26T10:33:52Z",
+                    "customer_master_key_spec": "SYMMETRIC_DEFAULT",
+                    "deletion_date": null,
+                    "description": "",
+                    "enabled": true,
+                    "expiration_model": "",
+                    "grant_tokens": null,
+                    "id": "ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                    "key_id": "alias/pg-kms-key",
+                    "key_manager": "CUSTOMER",
+                    "key_state": "Enabled",
+                    "key_usage": "ENCRYPT_DECRYPT",
+                    "origin": "AWS_KMS",
+                    "valid_to": null
+                  }
+                }
+              },
+              "root_module": {
+                "resources": [
+                  {
+                    "address": "data.aws_kms_key.by_alias",
+                    "mode": "data",
+                    "type": "aws_kms_key",
+                    "name": "by_alias",
+                    "provider_name": "aws",
+                    "schema_version": 0,
+                    "values": {
+                      "arn": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                      "aws_account_id": "670025224396",
+                      "creation_date": "2020-08-26T10:33:52Z",
+                      "customer_master_key_spec": "SYMMETRIC_DEFAULT",
+                      "deletion_date": null,
+                      "description": "",
+                      "enabled": true,
+                      "expiration_model": "",
+                      "grant_tokens": null,
+                      "id": "ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                      "key_id": "alias/pg-kms-key",
+                      "key_manager": "CUSTOMER",
+                      "key_state": "Enabled",
+                      "key_usage": "ENCRYPT_DECRYPT",
+                      "origin": "AWS_KMS",
+                      "valid_to": null
+                    }
+                  },
+                  {
+                    "address": "data.aws_kms_key.by_alias2",
+                    "mode": "data",
+                    "type": "aws_kms_key",
+                    "name": "by_alias2",
+                    "provider_name": "aws",
+                    "schema_version": 0,
+                    "values": {
+                      "arn": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                      "aws_account_id": "670025224396",
+                      "creation_date": "2020-08-26T10:33:52Z",
+                      "customer_master_key_spec": "SYMMETRIC_DEFAULT",
+                      "deletion_date": null,
+                      "description": "",
+                      "enabled": true,
+                      "expiration_model": "",
+                      "grant_tokens": null,
+                      "id": "ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                      "key_id": "alias/pg-kms-key",
+                      "key_manager": "CUSTOMER",
+                      "key_state": "Enabled",
+                      "key_usage": "ENCRYPT_DECRYPT",
+                      "origin": "AWS_KMS",
+                      "valid_to": null
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "configuration": {
+            "provider_config": {
+              "aws": {
+                "name": "aws",
+                "expressions": {
+                  "region": {
+                    "constant_value": "us-east-1"
+                  }
+                }
+              }
+            },
+            "root_module": {
+              "outputs": {
+                "key": {
+                  "expression": {
+                    "references": [
+                      "data.aws_kms_key.by_alias"
+                    ]
+                  }
+                }
+              },
+              "resources": [
+                {
+                  "address": "aws_s3_bucket.pg-kms-bucket-1",
+                  "mode": "managed",
+                  "type": "aws_s3_bucket",
+                  "name": "pg-kms-bucket-1",
+                  "provider_config_key": "aws",
+                  "expressions": {
+                    "bucket": {
+                      "constant_value": "pg-kms-mybucket-1"
+                    },
+                    "server_side_encryption_configuration": [
+                      {
+                        "rule": [
+                          {
+                            "apply_server_side_encryption_by_default": [
+                              {
+                                "kms_master_key_id": {
+                                  "constant_value": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708ss"
+                                },
+                                "sse_algorithm": {
+                                  "constant_value": "aws:kms"
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "schema_version": 0
+                },
+                {
+                  "address": "aws_s3_bucket.pg-kms-bucket-2",
+                  "mode": "managed",
+                  "type": "aws_s3_bucket",
+                  "name": "pg-kms-bucket-2",
+                  "provider_config_key": "aws",
+                  "expressions": {
+                    "bucket": {
+                      "constant_value": "pg-kms-mybucket-2"
+                    },
+                    "replication_configuration": [
+                      {
+                        "role": {
+                          "constant_value": "foo"
+                        },
+                        "rules": [
+                          {
+                            "destination": [
+                              {
+                                "bucket": {
+                                  "references": [
+                                    "aws_s3_bucket.pg-kms-bucket-1"
+                                  ]
+                                },
+                                "replica_kms_key_id": {
+                                  "constant_value": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd"
+                                },
+                                "storage_class": {
+                                  "constant_value": "STANDARD"
+                                }
+                              }
+                            ],
+                            "id": {
+                              "constant_value": "foobar"
+                            },
+                            "prefix": {
+                              "constant_value": "foo"
+                            },
+                            "source_selection_criteria": [
+                              {
+                                "sse_kms_encrypted_objects": [
+                                  {
+                                    "enabled": {
+                                      "constant_value": true
+                                    }
+                                  }
+                                ]
+                              }
+                            ],
+                            "status": {
+                              "constant_value": "Enabled"
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "server_side_encryption_configuration": [
+                      {
+                        "rule": [
+                          {
+                            "apply_server_side_encryption_by_default": [
+                              {
+                                "kms_master_key_id": {
+                                  "constant_value": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd"
+                                },
+                                "sse_algorithm": {
+                                  "constant_value": "aws:kms"
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "schema_version": 0
+                },
+                {
+                  "address": "random_string.rs",
+                  "mode": "managed",
+                  "type": "random_string",
+                  "name": "rs",
+                  "provider_config_key": "random",
+                  "expressions": {
+                    "length": {
+                      "constant_value": 6
+                    }
+                  },
+                  "schema_version": 1
+                },
+                {
+                  "address": "data.aws_kms_key.by_alias",
+                  "mode": "data",
+                  "type": "aws_kms_key",
+                  "name": "by_alias",
+                  "provider_config_key": "aws",
+                  "expressions": {
+                    "key_id": {
+                      "constant_value": "alias/pg-kms-key"
+                    }
+                  },
+                  "schema_version": 0
+                },
+                {
+                  "address": "data.aws_kms_key.by_alias2",
+                  "mode": "data",
+                  "type": "aws_kms_key",
+                  "name": "by_alias2",
+                  "provider_config_key": "aws",
+                  "expressions": {
+                    "key_id": {
+                      "constant_value": "alias/pg-kms-key"
+                    }
+                  },
+                  "schema_version": 0
+                }
+              ]
+            }
+          }
+        },
+        "tfrun": {
+          "workspace": {
+            "name": "wabtec-kms-keys",
+            "description": null,
+            "auto_apply": false,
+            "working_directory": null,
+            "tags": {}
+          },
+          "environment": {
+            "id": "env-t2daq8tprsifel8",
+            "name": "pg-opa-dev"
+          },
+          "vcs": null,
+          "cost_estimate": {
+            "prior_monthly_cost": 0,
+            "proposed_monthly_cost": 0,
+            "delta_monthly_cost": 0
+          },
+          "credentials": {
+            "ec2": "cred-stsfnc76g3pknk8"
+          },
+          "source": "cli",
+          "message": "Queued manually using Terraform",
+          "is_destroy": false,
+          "is_dry": true,
+          "created_by": {
+            "name": "",
+            "email": "peter@scalr.com",
+            "username": "peter@scalr.com"
+          }
+        }
+      },
+      "s3_valid": {
+        "tfplan": {
+          "format_version": "0.1",
+          "terraform_version": "0.12.28",
+          "variables": {
+            "arn": {
+              "value": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c70var"
+            }
+          },
+          "planned_values": {
+            "root_module": {
+              "resources": [
+                {
+                  "address": "aws_kms_key.pg-kms-key",
+                  "mode": "managed",
+                  "type": "aws_kms_key",
+                  "name": "pg-kms-key",
+                  "provider_name": "aws",
+                  "schema_version": 0,
+                  "values": {
+                    "customer_master_key_spec": "SYMMETRIC_DEFAULT",
+                    "deletion_window_in_days": null,
+                    "enable_key_rotation": false,
+                    "is_enabled": true,
+                    "key_usage": "ENCRYPT_DECRYPT",
+                    "tags": null
+                  }
+                },
+                {
+                  "address": "aws_s3_bucket.pg-kms-bucket-1",
+                  "mode": "managed",
+                  "type": "aws_s3_bucket",
+                  "name": "pg-kms-bucket-1",
+                  "provider_name": "aws",
+                  "schema_version": 0,
+                  "values": {
+                    "acl": "private",
+                    "bucket": "pg-kms-mybucket-1",
+                    "bucket_prefix": null,
+                    "cors_rule": [],
+                    "force_destroy": false,
+                    "grant": [],
+                    "lifecycle_rule": [],
+                    "logging": [],
+                    "object_lock_configuration": [],
+                    "policy": null,
+                    "replication_configuration": [],
+                    "server_side_encryption_configuration": [
+                      {
+                        "rule": [
+                          {
+                            "apply_server_side_encryption_by_default": [
+                              {
+                                "kms_master_key_id": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                                "sse_algorithm": "aws:kms"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ],
+                    "tags": null,
+                    "website": []
+                  }
+                }
+              ]
+            }
+          },
+          "resource_changes": [
+            {
+              "address": "aws_kms_key.pg-kms-key",
+              "mode": "managed",
+              "type": "aws_kms_key",
+              "name": "pg-kms-key",
+              "provider_name": "aws",
+              "change": {
+                "actions": [
+                  "create"
+                ],
+                "before": null,
+                "after": {
+                  "customer_master_key_spec": "SYMMETRIC_DEFAULT",
+                  "deletion_window_in_days": null,
+                  "enable_key_rotation": false,
+                  "is_enabled": true,
+                  "key_usage": "ENCRYPT_DECRYPT",
+                  "tags": null
+                },
+                "after_unknown": {
+                  "arn": true,
+                  "description": true,
+                  "id": true,
+                  "key_id": true,
+                  "policy": true
+                }
+              }
+            },
+            {
+              "address": "aws_s3_bucket.pg-kms-bucket-1",
+              "mode": "managed",
+              "type": "aws_s3_bucket",
+              "name": "pg-kms-bucket-1",
+              "provider_name": "aws",
+              "change": {
+                "actions": [
+                  "create"
+                ],
+                "before": null,
+                "after": {
+                  "acl": "private",
+                  "bucket": "pg-kms-mybucket-1",
+                  "bucket_prefix": null,
+                  "cors_rule": [],
+                  "force_destroy": false,
+                  "grant": [],
+                  "lifecycle_rule": [],
+                  "logging": [],
+                  "object_lock_configuration": [],
+                  "policy": null,
+                  "replication_configuration": [],
+                  "server_side_encryption_configuration": [
+                    {
+                      "rule": [
+                        {
+                          "apply_server_side_encryption_by_default": [
+                            {
+                              "kms_master_key_id": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                              "sse_algorithm": "aws:kms"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "tags": null,
+                  "website": []
+                },
+                "after_unknown": {
+                  "acceleration_status": true,
+                  "arn": true,
+                  "bucket_domain_name": true,
+                  "bucket_regional_domain_name": true,
+                  "cors_rule": [],
+                  "grant": [],
+                  "hosted_zone_id": true,
+                  "id": true,
+                  "lifecycle_rule": [],
+                  "logging": [],
+                  "object_lock_configuration": [],
+                  "region": true,
+                  "replication_configuration": [],
+                  "request_payer": true,
+                  "server_side_encryption_configuration": [
+                    {
+                      "rule": [
+                        {
+                          "apply_server_side_encryption_by_default": [
+                            {}
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "versioning": true,
+                  "website": [],
+                  "website_domain": true,
+                  "website_endpoint": true
+                }
+              }
+            }
+          ],
+          "prior_state": {
+            "format_version": "0.1",
+            "terraform_version": "0.12.28",
+            "values": {
+              "root_module": {
+                "resources": [
+                  {
+                    "address": "data.aws_kms_key.by_alias",
+                    "mode": "data",
+                    "type": "aws_kms_key",
+                    "name": "by_alias",
+                    "provider_name": "aws",
+                    "schema_version": 0,
+                    "values": {
+                      "arn": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                      "aws_account_id": "670025224396",
+                      "creation_date": "2020-08-26T10:33:52Z",
+                      "customer_master_key_spec": "SYMMETRIC_DEFAULT",
+                      "deletion_date": null,
+                      "description": "",
+                      "enabled": true,
+                      "expiration_model": "",
+                      "grant_tokens": null,
+                      "id": "ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                      "key_id": "alias/pg-kms-key",
+                      "key_manager": "CUSTOMER",
+                      "key_state": "Enabled",
+                      "key_usage": "ENCRYPT_DECRYPT",
+                      "origin": "AWS_KMS",
+                      "valid_to": null
+                    }
+                  },
+                  {
+                    "address": "data.aws_kms_key.by_alias2",
+                    "mode": "data",
+                    "type": "aws_kms_key",
+                    "name": "by_alias2",
+                    "provider_name": "aws",
+                    "schema_version": 0,
+                    "values": {
+                      "arn": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                      "aws_account_id": "670025224396",
+                      "creation_date": "2020-08-26T10:33:52Z",
+                      "customer_master_key_spec": "SYMMETRIC_DEFAULT",
+                      "deletion_date": null,
+                      "description": "",
+                      "enabled": true,
+                      "expiration_model": "",
+                      "grant_tokens": null,
+                      "id": "ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                      "key_id": "alias/pg-kms-key",
+                      "key_manager": "CUSTOMER",
+                      "key_state": "Enabled",
+                      "key_usage": "ENCRYPT_DECRYPT",
+                      "origin": "AWS_KMS",
+                      "valid_to": null
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "configuration": {
+            "provider_config": {
+              "aws": {
+                "name": "aws",
+                "expressions": {
+                  "region": {
+                    "constant_value": "us-east-1"
+                  }
+                }
+              }
+            },
+            "root_module": {
+              "resources": [
+                {
+                  "address": "aws_kms_key.pg-kms-key",
+                  "mode": "managed",
+                  "type": "aws_kms_key",
+                  "name": "pg-kms-key",
+                  "provider_config_key": "aws",
+                  "schema_version": 0
+                },
+                {
+                  "address": "aws_s3_bucket.pg-kms-bucket-1",
+                  "mode": "managed",
+                  "type": "aws_s3_bucket",
+                  "name": "pg-kms-bucket-1",
+                  "provider_config_key": "aws",
+                  "expressions": {
+                    "bucket": {
+                      "constant_value": "pg-kms-mybucket-1"
+                    },
+                    "server_side_encryption_configuration": [
+                      {
+                        "rule": [
+                          {
+                            "apply_server_side_encryption_by_default": [
+                              {
+                                "kms_master_key_id": {
+                                  "references": [
+                                    "data.aws_kms_key.by_alias"
+                                  ]
+                                },
+                                "sse_algorithm": {
+                                  "constant_value": "aws:kms"
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "schema_version": 0
+                },
+                {
+                  "address": "data.aws_kms_key.by_alias",
+                  "mode": "data",
+                  "type": "aws_kms_key",
+                  "name": "by_alias",
+                  "provider_config_key": "aws",
+                  "expressions": {
+                    "key_id": {
+                      "constant_value": "alias/pg-kms-key"
+                    }
+                  },
+                  "schema_version": 0
+                },
+                {
+                  "address": "data.aws_kms_key.by_alias2",
+                  "mode": "data",
+                  "type": "aws_kms_key",
+                  "name": "by_alias2",
+                  "provider_config_key": "aws",
+                  "expressions": {
+                    "key_id": {
+                      "constant_value": "alias/pg-kms-key"
+                    }
+                  },
+                  "schema_version": 0
+                }
+              ],
+              "variables": {
+                "arn": {
+                  "default": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c70var"
+                }
+              }
+            }
+          }
+        },
+        "tfrun": {
+          "workspace": {
+            "name": "wabtec-kms-keys",
+            "description": null,
+            "auto_apply": false,
+            "working_directory": null,
+            "tags": {}
+          },
+          "environment": {
+            "id": "env-t2daq8tprsifel8",
+            "name": "pg-opa-dev"
+          },
+          "vcs": null,
+          "cost_estimate": {
+            "prior_monthly_cost": 0,
+            "proposed_monthly_cost": 0,
+            "delta_monthly_cost": 0
+          },
+          "credentials": {
+            "ec2": "cred-stsfnc76g3pknk8"
+          },
+          "source": "cli",
+          "message": "Queued manually using Terraform",
+          "is_destroy": false,
+          "is_dry": true,
+          "created_by": {
+            "name": "",
+            "email": "peter@scalr.com",
+            "username": "peter@scalr.com"
+          }
+        }
+      },
+      "ebs_invalid": {
+        "tfplan": {
+          "format_version": "0.1",
+          "terraform_version": "0.12.28",
+          "variables": {
+            "arn": {
+              "value": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c70var"
+            }
+          },
+          "planned_values": {
+            "outputs": {
+              "key": {
+                "sensitive": false,
+                "value": {
+                  "arn": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                  "aws_account_id": "670025224396",
+                  "creation_date": "2020-08-26T10:33:52Z",
+                  "customer_master_key_spec": "SYMMETRIC_DEFAULT",
+                  "deletion_date": null,
+                  "description": "",
+                  "enabled": true,
+                  "expiration_model": "",
+                  "grant_tokens": null,
+                  "id": "ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                  "key_id": "alias/pg-kms-key",
+                  "key_manager": "CUSTOMER",
+                  "key_state": "Enabled",
+                  "key_usage": "ENCRYPT_DECRYPT",
+                  "origin": "AWS_KMS",
+                  "valid_to": null
+                }
+              }
+            },
+            "root_module": {
+              "resources": [
+                {
+                  "address": "aws_ebs_default_kms_key.pg-ebs-defaul-kms",
+                  "mode": "managed",
+                  "type": "aws_ebs_default_kms_key",
+                  "name": "pg-ebs-defaul-kms",
+                  "provider_name": "aws",
+                  "schema_version": 0
+                },
+                {
+                  "address": "aws_ebs_volume.pg-vol-1",
+                  "mode": "managed",
+                  "type": "aws_ebs_volume",
+                  "name": "pg-vol-1",
+                  "provider_name": "aws",
+                  "schema_version": 0,
+                  "values": {
+                    "availability_zone": "us-east-1a",
+                    "encrypted": true,
+                    "kms_key_id": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708ss",
+                    "multi_attach_enabled": null,
+                    "outpost_arn": null,
+                    "size": 40,
+                    "tags": null
+                  }
+                },
+                {
+                  "address": "aws_ebs_volume.pg-vol-2",
+                  "mode": "managed",
+                  "type": "aws_ebs_volume",
+                  "name": "pg-vol-2",
+                  "provider_name": "aws",
+                  "schema_version": 0,
+                  "values": {
+                    "availability_zone": "us-east-1a",
+                    "encrypted": true,
+                    "kms_key_id": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c70var",
+                    "multi_attach_enabled": null,
+                    "outpost_arn": null,
+                    "size": 40,
+                    "tags": null
+                  }
+                },
+                {
+                  "address": "aws_kms_key.pg-kms-key",
+                  "mode": "managed",
+                  "type": "aws_kms_key",
+                  "name": "pg-kms-key",
+                  "provider_name": "aws",
+                  "schema_version": 0,
+                  "values": {
+                    "customer_master_key_spec": "SYMMETRIC_DEFAULT",
+                    "deletion_window_in_days": null,
+                    "enable_key_rotation": false,
+                    "is_enabled": true,
+                    "key_usage": "ENCRYPT_DECRYPT",
+                    "tags": null
+                  }
+                },
+                {
+                  "address": "random_string.rs",
+                  "mode": "managed",
+                  "type": "random_string",
+                  "name": "rs",
+                  "provider_name": "random",
+                  "schema_version": 1,
+                  "values": {
+                    "keepers": null,
+                    "length": 6,
+                    "lower": true,
+                    "min_lower": 0,
+                    "min_numeric": 0,
+                    "min_special": 0,
+                    "min_upper": 0,
+                    "number": true,
+                    "override_special": null,
+                    "special": true,
+                    "upper": true
+                  }
+                }
+              ]
+            }
+          },
+          "resource_changes": [
+            {
+              "address": "aws_ebs_default_kms_key.pg-ebs-defaul-kms",
+              "mode": "managed",
+              "type": "aws_ebs_default_kms_key",
+              "name": "pg-ebs-defaul-kms",
+              "provider_name": "aws",
+              "change": {
+                "actions": [
+                  "create"
+                ],
+                "before": null,
+                "after": {},
+                "after_unknown": {
+                  "id": true,
+                  "key_arn": true
+                }
+              }
+            },
+            {
+              "address": "aws_ebs_volume.pg-vol-1",
+              "mode": "managed",
+              "type": "aws_ebs_volume",
+              "name": "pg-vol-1",
+              "provider_name": "aws",
+              "change": {
+                "actions": [
+                  "create"
+                ],
+                "before": null,
+                "after": {
+                  "availability_zone": "us-east-1a",
+                  "encrypted": true,
+                  "kms_key_id": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708ss",
+                  "multi_attach_enabled": null,
+                  "outpost_arn": null,
+                  "size": 40,
+                  "tags": null
+                },
+                "after_unknown": {
+                  "arn": true,
+                  "id": true,
+                  "iops": true,
+                  "snapshot_id": true,
+                  "type": true
+                }
+              }
+            },
+            {
+              "address": "aws_ebs_volume.pg-vol-2",
+              "mode": "managed",
+              "type": "aws_ebs_volume",
+              "name": "pg-vol-2",
+              "provider_name": "aws",
+              "change": {
+                "actions": [
+                  "create"
+                ],
+                "before": null,
+                "after": {
+                  "availability_zone": "us-east-1a",
+                  "encrypted": true,
+                  "kms_key_id": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c70var",
+                  "multi_attach_enabled": null,
+                  "outpost_arn": null,
+                  "size": 40,
+                  "tags": null
+                },
+                "after_unknown": {
+                  "arn": true,
+                  "id": true,
+                  "iops": true,
+                  "snapshot_id": true,
+                  "type": true
+                }
+              }
+            },
+            {
+              "address": "aws_kms_key.pg-kms-key",
+              "mode": "managed",
+              "type": "aws_kms_key",
+              "name": "pg-kms-key",
+              "provider_name": "aws",
+              "change": {
+                "actions": [
+                  "create"
+                ],
+                "before": null,
+                "after": {
+                  "customer_master_key_spec": "SYMMETRIC_DEFAULT",
+                  "deletion_window_in_days": null,
+                  "enable_key_rotation": false,
+                  "is_enabled": true,
+                  "key_usage": "ENCRYPT_DECRYPT",
+                  "tags": null
+                },
+                "after_unknown": {
+                  "arn": true,
+                  "description": true,
+                  "id": true,
+                  "key_id": true,
+                  "policy": true
+                }
+              }
+            },
+            {
+              "address": "random_string.rs",
+              "mode": "managed",
+              "type": "random_string",
+              "name": "rs",
+              "provider_name": "random",
+              "change": {
+                "actions": [
+                  "create"
+                ],
+                "before": null,
+                "after": {
+                  "keepers": null,
+                  "length": 6,
+                  "lower": true,
+                  "min_lower": 0,
+                  "min_numeric": 0,
+                  "min_special": 0,
+                  "min_upper": 0,
+                  "number": true,
+                  "override_special": null,
+                  "special": true,
+                  "upper": true
+                },
+                "after_unknown": {
+                  "id": true,
+                  "result": true
+                }
+              }
+            }
+          ],
+          "output_changes": {
+            "key": {
+              "actions": [
+                "create"
+              ],
+              "before": null,
+              "after": {
+                "arn": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                "aws_account_id": "670025224396",
+                "creation_date": "2020-08-26T10:33:52Z",
+                "customer_master_key_spec": "SYMMETRIC_DEFAULT",
+                "deletion_date": null,
+                "description": "",
+                "enabled": true,
+                "expiration_model": "",
+                "grant_tokens": null,
+                "id": "ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                "key_id": "alias/pg-kms-key",
+                "key_manager": "CUSTOMER",
+                "key_state": "Enabled",
+                "key_usage": "ENCRYPT_DECRYPT",
+                "origin": "AWS_KMS",
+                "valid_to": null
+              },
+              "after_unknown": false
+            }
+          },
+          "prior_state": {
+            "format_version": "0.1",
+            "terraform_version": "0.12.28",
+            "values": {
+              "outputs": {
+                "key": {
+                  "sensitive": false,
+                  "value": {
+                    "arn": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                    "aws_account_id": "670025224396",
+                    "creation_date": "2020-08-26T10:33:52Z",
+                    "customer_master_key_spec": "SYMMETRIC_DEFAULT",
+                    "deletion_date": null,
+                    "description": "",
+                    "enabled": true,
+                    "expiration_model": "",
+                    "grant_tokens": null,
+                    "id": "ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                    "key_id": "alias/pg-kms-key",
+                    "key_manager": "CUSTOMER",
+                    "key_state": "Enabled",
+                    "key_usage": "ENCRYPT_DECRYPT",
+                    "origin": "AWS_KMS",
+                    "valid_to": null
+                  }
+                }
+              },
+              "root_module": {
+                "resources": [
+                  {
+                    "address": "data.aws_kms_key.by_alias",
+                    "mode": "data",
+                    "type": "aws_kms_key",
+                    "name": "by_alias",
+                    "provider_name": "aws",
+                    "schema_version": 0,
+                    "values": {
+                      "arn": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                      "aws_account_id": "670025224396",
+                      "creation_date": "2020-08-26T10:33:52Z",
+                      "customer_master_key_spec": "SYMMETRIC_DEFAULT",
+                      "deletion_date": null,
+                      "description": "",
+                      "enabled": true,
+                      "expiration_model": "",
+                      "grant_tokens": null,
+                      "id": "ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                      "key_id": "alias/pg-kms-key",
+                      "key_manager": "CUSTOMER",
+                      "key_state": "Enabled",
+                      "key_usage": "ENCRYPT_DECRYPT",
+                      "origin": "AWS_KMS",
+                      "valid_to": null
+                    }
+                  },
+                  {
+                    "address": "data.aws_kms_key.by_alias2",
+                    "mode": "data",
+                    "type": "aws_kms_key",
+                    "name": "by_alias2",
+                    "provider_name": "aws",
+                    "schema_version": 0,
+                    "values": {
+                      "arn": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                      "aws_account_id": "670025224396",
+                      "creation_date": "2020-08-26T10:33:52Z",
+                      "customer_master_key_spec": "SYMMETRIC_DEFAULT",
+                      "deletion_date": null,
+                      "description": "",
+                      "enabled": true,
+                      "expiration_model": "",
+                      "grant_tokens": null,
+                      "id": "ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                      "key_id": "alias/pg-kms-key",
+                      "key_manager": "CUSTOMER",
+                      "key_state": "Enabled",
+                      "key_usage": "ENCRYPT_DECRYPT",
+                      "origin": "AWS_KMS",
+                      "valid_to": null
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "configuration": {
+            "provider_config": {
+              "aws": {
+                "name": "aws",
+                "expressions": {
+                  "region": {
+                    "constant_value": "us-east-1"
+                  }
+                }
+              }
+            },
+            "root_module": {
+              "outputs": {
+                "key": {
+                  "expression": {
+                    "references": [
+                      "data.aws_kms_key.by_alias"
+                    ]
+                  }
+                }
+              },
+              "resources": [
+                {
+                  "address": "aws_ebs_default_kms_key.pg-ebs-defaul-kms",
+                  "mode": "managed",
+                  "type": "aws_ebs_default_kms_key",
+                  "name": "pg-ebs-defaul-kms",
+                  "provider_config_key": "aws",
+                  "expressions": {
+                    "key_arn": {
+                      "references": [
+                        "aws_kms_key.pg-kms-key"
+                      ]
+                    }
+                  },
+                  "schema_version": 0
+                },
+                {
+                  "address": "aws_ebs_volume.pg-vol-1",
+                  "mode": "managed",
+                  "type": "aws_ebs_volume",
+                  "name": "pg-vol-1",
+                  "provider_config_key": "aws",
+                  "expressions": {
+                    "availability_zone": {
+                      "constant_value": "us-east-1a"
+                    },
+                    "encrypted": {
+                      "constant_value": true
+                    },
+                    "kms_key_id": {
+                      "constant_value": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708ss"
+                    },
+                    "size": {
+                      "constant_value": 40
+                    }
+                  },
+                  "schema_version": 0
+                },
+                {
+                  "address": "aws_ebs_volume.pg-vol-2",
+                  "mode": "managed",
+                  "type": "aws_ebs_volume",
+                  "name": "pg-vol-2",
+                  "provider_config_key": "aws",
+                  "expressions": {
+                    "availability_zone": {
+                      "constant_value": "us-east-1a"
+                    },
+                    "encrypted": {
+                      "constant_value": true
+                    },
+                    "kms_key_id": {
+                      "references": [
+                        "var.arn"
+                      ]
+                    },
+                    "size": {
+                      "constant_value": 40
+                    }
+                  },
+                  "schema_version": 0
+                },
+                {
+                  "address": "aws_kms_key.pg-kms-key",
+                  "mode": "managed",
+                  "type": "aws_kms_key",
+                  "name": "pg-kms-key",
+                  "provider_config_key": "aws",
+                  "schema_version": 0
+                },
+                {
+                  "address": "random_string.rs",
+                  "mode": "managed",
+                  "type": "random_string",
+                  "name": "rs",
+                  "provider_config_key": "random",
+                  "expressions": {
+                    "length": {
+                      "constant_value": 6
+                    }
+                  },
+                  "schema_version": 1
+                },
+                {
+                  "address": "data.aws_kms_key.by_alias",
+                  "mode": "data",
+                  "type": "aws_kms_key",
+                  "name": "by_alias",
+                  "provider_config_key": "aws",
+                  "expressions": {
+                    "key_id": {
+                      "constant_value": "alias/pg-kms-key"
+                    }
+                  },
+                  "schema_version": 0
+                },
+                {
+                  "address": "data.aws_kms_key.by_alias2",
+                  "mode": "data",
+                  "type": "aws_kms_key",
+                  "name": "by_alias2",
+                  "provider_config_key": "aws",
+                  "expressions": {
+                    "key_id": {
+                      "constant_value": "alias/pg-kms-key"
+                    }
+                  },
+                  "schema_version": 0
+                }
+              ],
+              "variables": {
+                "arn": {
+                  "default": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c70var"
+                }
+              }
+            }
+          }
+        },
+        "tfrun": {
+          "workspace": {
+            "name": "wabtec-kms-keys",
+            "description": null,
+            "auto_apply": false,
+            "working_directory": null,
+            "tags": {}
+          },
+          "environment": {
+            "id": "env-t2daq8tprsifel8",
+            "name": "pg-opa-dev"
+          },
+          "vcs": null,
+          "cost_estimate": {
+            "prior_monthly_cost": 0,
+            "proposed_monthly_cost": 8,
+            "delta_monthly_cost": 8
+          },
+          "credentials": {
+            "ec2": "cred-stsfnc76g3pknk8"
+          },
+          "source": "cli",
+          "message": "Queued manually using Terraform",
+          "is_destroy": false,
+          "is_dry": true,
+          "created_by": {
+            "name": "",
+            "email": "peter@scalr.com",
+            "username": "peter@scalr.com"
+          }
+        }
+      },
+      "ebs_valid": {
+        "tfplan": {
+          "format_version": "0.1",
+          "terraform_version": "0.12.28",
+          "variables": {
+            "arn": {
+              "value": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c70var"
+            }
+          },
+          "planned_values": {
+            "root_module": {
+              "resources": [
+                {
+                  "address": "aws_ebs_volume.pg-vol-1",
+                  "mode": "managed",
+                  "type": "aws_ebs_volume",
+                  "name": "pg-vol-1",
+                  "provider_name": "aws",
+                  "schema_version": 0,
+                  "values": {
+                    "availability_zone": "us-east-1a",
+                    "encrypted": true,
+                    "kms_key_id": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                    "multi_attach_enabled": null,
+                    "outpost_arn": null,
+                    "size": 40,
+                    "tags": null
+                  }
+                },
+                {
+                  "address": "aws_kms_key.pg-kms-key",
+                  "mode": "managed",
+                  "type": "aws_kms_key",
+                  "name": "pg-kms-key",
+                  "provider_name": "aws",
+                  "schema_version": 0,
+                  "values": {
+                    "customer_master_key_spec": "SYMMETRIC_DEFAULT",
+                    "deletion_window_in_days": null,
+                    "enable_key_rotation": false,
+                    "is_enabled": true,
+                    "key_usage": "ENCRYPT_DECRYPT",
+                    "tags": null
+                  }
+                }
+              ]
+            }
+          },
+          "resource_changes": [
+            {
+              "address": "aws_ebs_volume.pg-vol-1",
+              "mode": "managed",
+              "type": "aws_ebs_volume",
+              "name": "pg-vol-1",
+              "provider_name": "aws",
+              "change": {
+                "actions": [
+                  "create"
+                ],
+                "before": null,
+                "after": {
+                  "availability_zone": "us-east-1a",
+                  "encrypted": true,
+                  "kms_key_id": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                  "multi_attach_enabled": null,
+                  "outpost_arn": null,
+                  "size": 40,
+                  "tags": null
+                },
+                "after_unknown": {
+                  "arn": true,
+                  "id": true,
+                  "iops": true,
+                  "snapshot_id": true,
+                  "type": true
+                }
+              }
+            },
+            {
+              "address": "aws_kms_key.pg-kms-key",
+              "mode": "managed",
+              "type": "aws_kms_key",
+              "name": "pg-kms-key",
+              "provider_name": "aws",
+              "change": {
+                "actions": [
+                  "create"
+                ],
+                "before": null,
+                "after": {
+                  "customer_master_key_spec": "SYMMETRIC_DEFAULT",
+                  "deletion_window_in_days": null,
+                  "enable_key_rotation": false,
+                  "is_enabled": true,
+                  "key_usage": "ENCRYPT_DECRYPT",
+                  "tags": null
+                },
+                "after_unknown": {
+                  "arn": true,
+                  "description": true,
+                  "id": true,
+                  "key_id": true,
+                  "policy": true
+                }
+              }
+            }
+          ],
+          "prior_state": {
+            "format_version": "0.1",
+            "terraform_version": "0.12.28",
+            "values": {
+              "root_module": {
+                "resources": [
+                  {
+                    "address": "data.aws_kms_key.by_alias",
+                    "mode": "data",
+                    "type": "aws_kms_key",
+                    "name": "by_alias",
+                    "provider_name": "aws",
+                    "schema_version": 0,
+                    "values": {
+                      "arn": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                      "aws_account_id": "670025224396",
+                      "creation_date": "2020-08-26T10:33:52Z",
+                      "customer_master_key_spec": "SYMMETRIC_DEFAULT",
+                      "deletion_date": null,
+                      "description": "",
+                      "enabled": true,
+                      "expiration_model": "",
+                      "grant_tokens": null,
+                      "id": "ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                      "key_id": "alias/pg-kms-key",
+                      "key_manager": "CUSTOMER",
+                      "key_state": "Enabled",
+                      "key_usage": "ENCRYPT_DECRYPT",
+                      "origin": "AWS_KMS",
+                      "valid_to": null
+                    }
+                  },
+                  {
+                    "address": "data.aws_kms_key.by_alias2",
+                    "mode": "data",
+                    "type": "aws_kms_key",
+                    "name": "by_alias2",
+                    "provider_name": "aws",
+                    "schema_version": 0,
+                    "values": {
+                      "arn": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                      "aws_account_id": "670025224396",
+                      "creation_date": "2020-08-26T10:33:52Z",
+                      "customer_master_key_spec": "SYMMETRIC_DEFAULT",
+                      "deletion_date": null,
+                      "description": "",
+                      "enabled": true,
+                      "expiration_model": "",
+                      "grant_tokens": null,
+                      "id": "ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                      "key_id": "alias/pg-kms-key",
+                      "key_manager": "CUSTOMER",
+                      "key_state": "Enabled",
+                      "key_usage": "ENCRYPT_DECRYPT",
+                      "origin": "AWS_KMS",
+                      "valid_to": null
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "configuration": {
+            "provider_config": {
+              "aws": {
+                "name": "aws",
+                "expressions": {
+                  "region": {
+                    "constant_value": "us-east-1"
+                  }
+                }
+              }
+            },
+            "root_module": {
+              "resources": [
+                {
+                  "address": "aws_ebs_volume.pg-vol-1",
+                  "mode": "managed",
+                  "type": "aws_ebs_volume",
+                  "name": "pg-vol-1",
+                  "provider_config_key": "aws",
+                  "expressions": {
+                    "availability_zone": {
+                      "constant_value": "us-east-1a"
+                    },
+                    "encrypted": {
+                      "constant_value": true
+                    },
+                    "kms_key_id": {
+                      "references": [
+                        "data.aws_kms_key.by_alias"
+                      ]
+                    },
+                    "size": {
+                      "constant_value": 40
+                    }
+                  },
+                  "schema_version": 0
+                },
+                {
+                  "address": "aws_kms_key.pg-kms-key",
+                  "mode": "managed",
+                  "type": "aws_kms_key",
+                  "name": "pg-kms-key",
+                  "provider_config_key": "aws",
+                  "schema_version": 0
+                },
+                {
+                  "address": "data.aws_kms_key.by_alias",
+                  "mode": "data",
+                  "type": "aws_kms_key",
+                  "name": "by_alias",
+                  "provider_config_key": "aws",
+                  "expressions": {
+                    "key_id": {
+                      "constant_value": "alias/pg-kms-key"
+                    }
+                  },
+                  "schema_version": 0
+                },
+                {
+                  "address": "data.aws_kms_key.by_alias2",
+                  "mode": "data",
+                  "type": "aws_kms_key",
+                  "name": "by_alias2",
+                  "provider_config_key": "aws",
+                  "expressions": {
+                    "key_id": {
+                      "constant_value": "alias/pg-kms-key"
+                    }
+                  },
+                  "schema_version": 0
+                }
+              ],
+              "variables": {
+                "arn": {
+                  "default": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c70var"
+                }
+              }
+            }
+          }
+        },
+        "tfrun": {
+          "workspace": {
+            "name": "wabtec-kms-keys",
+            "description": null,
+            "auto_apply": false,
+            "working_directory": null,
+            "tags": {}
+          },
+          "environment": {
+            "id": "env-t2daq8tprsifel8",
+            "name": "pg-opa-dev"
+          },
+          "vcs": null,
+          "cost_estimate": {
+            "prior_monthly_cost": 0,
+            "proposed_monthly_cost": 4,
+            "delta_monthly_cost": 4
+          },
+          "credentials": {
+            "ec2": "cred-stsfnc76g3pknk8"
+          },
+          "source": "cli",
+          "message": "Queued manually using Terraform",
+          "is_destroy": false,
+          "is_dry": true,
+          "created_by": {
+            "name": "",
+            "email": "peter@scalr.com",
+            "username": "peter@scalr.com"
+          }
+        }
+      }
+    }
+  }
+  

--- a/aws/enforce_kms_key_names.mock.json
+++ b/aws/enforce_kms_key_names.mock.json
@@ -650,7 +650,7 @@
                   "provider_config_key": "aws",
                   "expressions": {
                     "key_id": {
-                      "constant_value": "alias/pg-kms-key"
+                      "constant_value": "alias/pg-kms-key-x"
                     }
                   },
                   "schema_version": 0
@@ -663,7 +663,7 @@
                   "provider_config_key": "aws",
                   "expressions": {
                     "key_id": {
-                      "constant_value": "alias/pg-kms-key"
+                      "constant_value": "alias/pg-kms-key-x"
                     }
                   },
                   "schema_version": 0

--- a/aws/enforce_kms_key_names.mock.json
+++ b/aws/enforce_kms_key_names.mock.json
@@ -699,8 +699,8 @@
           "is_dry": true,
           "created_by": {
             "name": "",
-            "email": "peter@scalr.com",
-            "username": "peter@scalr.com"
+            "email": "xxxxxxx@scalr.com",
+            "username": "xxxxxxx@scalr.com"
           }
         }
       },
@@ -1053,8 +1053,8 @@
           "is_dry": true,
           "created_by": {
             "name": "",
-            "email": "peter@scalr.com",
-            "username": "peter@scalr.com"
+            "email": "xxxxxxx@scalr.com",
+            "username": "xxxxxxx@scalr.com"
           }
         }
       },
@@ -1589,8 +1589,8 @@
           "is_dry": true,
           "created_by": {
             "name": "",
-            "email": "peter@scalr.com",
-            "username": "peter@scalr.com"
+            "email": "xxxxxxx@scalr.com",
+            "username": "xxxxxxx@scalr.com"
           }
         }
       },
@@ -1870,8 +1870,8 @@
           "is_dry": true,
           "created_by": {
             "name": "",
-            "email": "peter@scalr.com",
-            "username": "peter@scalr.com"
+            "email": "xxxxxxx@scalr.com",
+            "username": "xxxxxxx@scalr.com"
           }
         }
       }

--- a/aws/enforce_kms_key_names.mock.json
+++ b/aws/enforce_kms_key_names.mock.json
@@ -9,8 +9,8 @@
               "key": {
                 "sensitive": false,
                 "value": {
-                  "arn": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
-                  "aws_account_id": "670025224396",
+                  "arn": "arn:aws:kms:us-east-1:xxxxxxxxxxxxxx:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                  "aws_account_id": "xxxxxxxxxxxxxx",
                   "creation_date": "2020-08-26T10:33:52Z",
                   "customer_master_key_spec": "SYMMETRIC_DEFAULT",
                   "deletion_date": null,
@@ -55,7 +55,7 @@
                           {
                             "apply_server_side_encryption_by_default": [
                               {
-                                "kms_master_key_id": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708ss",
+                                "kms_master_key_id": "arn:aws:kms:us-east-1:xxxxxxxxxxxxxx:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708ss",
                                 "sse_algorithm": "aws:kms"
                               }
                             ]
@@ -94,7 +94,7 @@
                               {
                                 "access_control_translation": [],
                                 "account_id": "",
-                                "replica_kms_key_id": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                                "replica_kms_key_id": "arn:aws:kms:us-east-1:xxxxxxxxxxxxxx:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
                                 "storage_class": "STANDARD"
                               }
                             ],
@@ -122,7 +122,7 @@
                           {
                             "apply_server_side_encryption_by_default": [
                               {
-                                "kms_master_key_id": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                                "kms_master_key_id": "arn:aws:kms:us-east-1:xxxxxxxxxxxxxx:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
                                 "sse_algorithm": "aws:kms"
                               }
                             ]
@@ -188,7 +188,7 @@
                         {
                           "apply_server_side_encryption_by_default": [
                             {
-                              "kms_master_key_id": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708ss",
+                              "kms_master_key_id": "arn:aws:kms:us-east-1:xxxxxxxxxxxxxx:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708ss",
                               "sse_algorithm": "aws:kms"
                             }
                           ]
@@ -263,7 +263,7 @@
                             {
                               "access_control_translation": [],
                               "account_id": "",
-                              "replica_kms_key_id": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                              "replica_kms_key_id": "arn:aws:kms:us-east-1:xxxxxxxxxxxxxx:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
                               "storage_class": "STANDARD"
                             }
                           ],
@@ -291,7 +291,7 @@
                         {
                           "apply_server_side_encryption_by_default": [
                             {
-                              "kms_master_key_id": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                              "kms_master_key_id": "arn:aws:kms:us-east-1:xxxxxxxxxxxxxx:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
                               "sse_algorithm": "aws:kms"
                             }
                           ]
@@ -394,8 +394,8 @@
               ],
               "before": null,
               "after": {
-                "arn": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
-                "aws_account_id": "670025224396",
+                "arn": "arn:aws:kms:us-east-1:xxxxxxxxxxxxxx:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                "aws_account_id": "xxxxxxxxxxxxxx",
                 "creation_date": "2020-08-26T10:33:52Z",
                 "customer_master_key_spec": "SYMMETRIC_DEFAULT",
                 "deletion_date": null,
@@ -422,8 +422,8 @@
                 "key": {
                   "sensitive": false,
                   "value": {
-                    "arn": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
-                    "aws_account_id": "670025224396",
+                    "arn": "arn:aws:kms:us-east-1:xxxxxxxxxxxxxx:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                    "aws_account_id": "xxxxxxxxxxxxxx",
                     "creation_date": "2020-08-26T10:33:52Z",
                     "customer_master_key_spec": "SYMMETRIC_DEFAULT",
                     "deletion_date": null,
@@ -451,8 +451,8 @@
                     "provider_name": "aws",
                     "schema_version": 0,
                     "values": {
-                      "arn": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
-                      "aws_account_id": "670025224396",
+                      "arn": "arn:aws:kms:us-east-1:xxxxxxxxxxxxxx:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                      "aws_account_id": "xxxxxxxxxxxxxx",
                       "creation_date": "2020-08-26T10:33:52Z",
                       "customer_master_key_spec": "SYMMETRIC_DEFAULT",
                       "deletion_date": null,
@@ -477,8 +477,8 @@
                     "provider_name": "aws",
                     "schema_version": 0,
                     "values": {
-                      "arn": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
-                      "aws_account_id": "670025224396",
+                      "arn": "arn:aws:kms:us-east-1:xxxxxxxxxxxxxx:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                      "aws_account_id": "xxxxxxxxxxxxxx",
                       "creation_date": "2020-08-26T10:33:52Z",
                       "customer_master_key_spec": "SYMMETRIC_DEFAULT",
                       "deletion_date": null,
@@ -538,7 +538,7 @@
                             "apply_server_side_encryption_by_default": [
                               {
                                 "kms_master_key_id": {
-                                  "constant_value": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708ss"
+                                  "constant_value": "arn:aws:kms:us-east-1:xxxxxxxxxxxxxx:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708ss"
                                 },
                                 "sse_algorithm": {
                                   "constant_value": "aws:kms"
@@ -577,7 +577,7 @@
                                   ]
                                 },
                                 "replica_kms_key_id": {
-                                  "constant_value": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd"
+                                  "constant_value": "arn:aws:kms:us-east-1:xxxxxxxxxxxxxx:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd"
                                 },
                                 "storage_class": {
                                   "constant_value": "STANDARD"
@@ -615,7 +615,7 @@
                             "apply_server_side_encryption_by_default": [
                               {
                                 "kms_master_key_id": {
-                                  "constant_value": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd"
+                                  "constant_value": "arn:aws:kms:us-east-1:xxxxxxxxxxxxxx:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd"
                                 },
                                 "sse_algorithm": {
                                   "constant_value": "aws:kms"
@@ -710,7 +710,7 @@
           "terraform_version": "0.12.28",
           "variables": {
             "arn": {
-              "value": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c70var"
+              "value": "arn:aws:kms:us-east-1:xxxxxxxxxxxxxx:key/ca4fb1d0-d899-4ef4-b825-0b7d02c70var"
             }
           },
           "planned_values": {
@@ -757,7 +757,7 @@
                           {
                             "apply_server_side_encryption_by_default": [
                               {
-                                "kms_master_key_id": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                                "kms_master_key_id": "arn:aws:kms:us-east-1:xxxxxxxxxxxxxx:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
                                 "sse_algorithm": "aws:kms"
                               }
                             ]
@@ -830,7 +830,7 @@
                         {
                           "apply_server_side_encryption_by_default": [
                             {
-                              "kms_master_key_id": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                              "kms_master_key_id": "arn:aws:kms:us-east-1:xxxxxxxxxxxxxx:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
                               "sse_algorithm": "aws:kms"
                             }
                           ]
@@ -889,8 +889,8 @@
                     "provider_name": "aws",
                     "schema_version": 0,
                     "values": {
-                      "arn": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
-                      "aws_account_id": "670025224396",
+                      "arn": "arn:aws:kms:us-east-1:xxxxxxxxxxxxxx:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                      "aws_account_id": "xxxxxxxxxxxxxx",
                       "creation_date": "2020-08-26T10:33:52Z",
                       "customer_master_key_spec": "SYMMETRIC_DEFAULT",
                       "deletion_date": null,
@@ -915,8 +915,8 @@
                     "provider_name": "aws",
                     "schema_version": 0,
                     "values": {
-                      "arn": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
-                      "aws_account_id": "670025224396",
+                      "arn": "arn:aws:kms:us-east-1:xxxxxxxxxxxxxx:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                      "aws_account_id": "xxxxxxxxxxxxxx",
                       "creation_date": "2020-08-26T10:33:52Z",
                       "customer_master_key_spec": "SYMMETRIC_DEFAULT",
                       "deletion_date": null,
@@ -1020,7 +1020,7 @@
               ],
               "variables": {
                 "arn": {
-                  "default": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c70var"
+                  "default": "arn:aws:kms:us-east-1:xxxxxxxxxxxxxx:key/ca4fb1d0-d899-4ef4-b825-0b7d02c70var"
                 }
               }
             }
@@ -1064,7 +1064,7 @@
           "terraform_version": "0.12.28",
           "variables": {
             "arn": {
-              "value": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c70var"
+              "value": "arn:aws:kms:us-east-1:xxxxxxxxxxxxxx:key/ca4fb1d0-d899-4ef4-b825-0b7d02c70var"
             }
           },
           "planned_values": {
@@ -1072,8 +1072,8 @@
               "key": {
                 "sensitive": false,
                 "value": {
-                  "arn": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
-                  "aws_account_id": "670025224396",
+                  "arn": "arn:aws:kms:us-east-1:xxxxxxxxxxxxxx:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                  "aws_account_id": "xxxxxxxxxxxxxx",
                   "creation_date": "2020-08-26T10:33:52Z",
                   "customer_master_key_spec": "SYMMETRIC_DEFAULT",
                   "deletion_date": null,
@@ -1111,7 +1111,7 @@
                   "values": {
                     "availability_zone": "us-east-1a",
                     "encrypted": true,
-                    "kms_key_id": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708ss",
+                    "kms_key_id": "arn:aws:kms:us-east-1:xxxxxxxxxxxxxx:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708ss",
                     "multi_attach_enabled": null,
                     "outpost_arn": null,
                     "size": 40,
@@ -1128,7 +1128,7 @@
                   "values": {
                     "availability_zone": "us-east-1a",
                     "encrypted": true,
-                    "kms_key_id": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c70var",
+                    "kms_key_id": "arn:aws:kms:us-east-1:xxxxxxxxxxxxxx:key/ca4fb1d0-d899-4ef4-b825-0b7d02c70var",
                     "multi_attach_enabled": null,
                     "outpost_arn": null,
                     "size": 40,
@@ -1208,7 +1208,7 @@
                 "after": {
                   "availability_zone": "us-east-1a",
                   "encrypted": true,
-                  "kms_key_id": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708ss",
+                  "kms_key_id": "arn:aws:kms:us-east-1:xxxxxxxxxxxxxx:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708ss",
                   "multi_attach_enabled": null,
                   "outpost_arn": null,
                   "size": 40,
@@ -1237,7 +1237,7 @@
                 "after": {
                   "availability_zone": "us-east-1a",
                   "encrypted": true,
-                  "kms_key_id": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c70var",
+                  "kms_key_id": "arn:aws:kms:us-east-1:xxxxxxxxxxxxxx:key/ca4fb1d0-d899-4ef4-b825-0b7d02c70var",
                   "multi_attach_enabled": null,
                   "outpost_arn": null,
                   "size": 40,
@@ -1318,8 +1318,8 @@
               ],
               "before": null,
               "after": {
-                "arn": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
-                "aws_account_id": "670025224396",
+                "arn": "arn:aws:kms:us-east-1:xxxxxxxxxxxxxx:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                "aws_account_id": "xxxxxxxxxxxxxx",
                 "creation_date": "2020-08-26T10:33:52Z",
                 "customer_master_key_spec": "SYMMETRIC_DEFAULT",
                 "deletion_date": null,
@@ -1346,8 +1346,8 @@
                 "key": {
                   "sensitive": false,
                   "value": {
-                    "arn": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
-                    "aws_account_id": "670025224396",
+                    "arn": "arn:aws:kms:us-east-1:xxxxxxxxxxxxxx:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                    "aws_account_id": "xxxxxxxxxxxxxx",
                     "creation_date": "2020-08-26T10:33:52Z",
                     "customer_master_key_spec": "SYMMETRIC_DEFAULT",
                     "deletion_date": null,
@@ -1375,8 +1375,8 @@
                     "provider_name": "aws",
                     "schema_version": 0,
                     "values": {
-                      "arn": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
-                      "aws_account_id": "670025224396",
+                      "arn": "arn:aws:kms:us-east-1:xxxxxxxxxxxxxx:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                      "aws_account_id": "xxxxxxxxxxxxxx",
                       "creation_date": "2020-08-26T10:33:52Z",
                       "customer_master_key_spec": "SYMMETRIC_DEFAULT",
                       "deletion_date": null,
@@ -1401,8 +1401,8 @@
                     "provider_name": "aws",
                     "schema_version": 0,
                     "values": {
-                      "arn": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
-                      "aws_account_id": "670025224396",
+                      "arn": "arn:aws:kms:us-east-1:xxxxxxxxxxxxxx:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                      "aws_account_id": "xxxxxxxxxxxxxx",
                       "creation_date": "2020-08-26T10:33:52Z",
                       "customer_master_key_spec": "SYMMETRIC_DEFAULT",
                       "deletion_date": null,
@@ -1474,7 +1474,7 @@
                       "constant_value": true
                     },
                     "kms_key_id": {
-                      "constant_value": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708ss"
+                      "constant_value": "arn:aws:kms:us-east-1:xxxxxxxxxxxxxx:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708ss"
                     },
                     "size": {
                       "constant_value": 40
@@ -1556,7 +1556,7 @@
               ],
               "variables": {
                 "arn": {
-                  "default": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c70var"
+                  "default": "arn:aws:kms:us-east-1:xxxxxxxxxxxxxx:key/ca4fb1d0-d899-4ef4-b825-0b7d02c70var"
                 }
               }
             }
@@ -1600,7 +1600,7 @@
           "terraform_version": "0.12.28",
           "variables": {
             "arn": {
-              "value": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c70var"
+              "value": "arn:aws:kms:us-east-1:xxxxxxxxxxxxxx:key/ca4fb1d0-d899-4ef4-b825-0b7d02c70var"
             }
           },
           "planned_values": {
@@ -1616,7 +1616,7 @@
                   "values": {
                     "availability_zone": "us-east-1a",
                     "encrypted": true,
-                    "kms_key_id": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                    "kms_key_id": "arn:aws:kms:us-east-1:xxxxxxxxxxxxxx:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
                     "multi_attach_enabled": null,
                     "outpost_arn": null,
                     "size": 40,
@@ -1657,7 +1657,7 @@
                 "after": {
                   "availability_zone": "us-east-1a",
                   "encrypted": true,
-                  "kms_key_id": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                  "kms_key_id": "arn:aws:kms:us-east-1:xxxxxxxxxxxxxx:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
                   "multi_attach_enabled": null,
                   "outpost_arn": null,
                   "size": 40,
@@ -1715,8 +1715,8 @@
                     "provider_name": "aws",
                     "schema_version": 0,
                     "values": {
-                      "arn": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
-                      "aws_account_id": "670025224396",
+                      "arn": "arn:aws:kms:us-east-1:xxxxxxxxxxxxxx:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                      "aws_account_id": "xxxxxxxxxxxxxx",
                       "creation_date": "2020-08-26T10:33:52Z",
                       "customer_master_key_spec": "SYMMETRIC_DEFAULT",
                       "deletion_date": null,
@@ -1741,8 +1741,8 @@
                     "provider_name": "aws",
                     "schema_version": 0,
                     "values": {
-                      "arn": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
-                      "aws_account_id": "670025224396",
+                      "arn": "arn:aws:kms:us-east-1:xxxxxxxxxxxxxx:key/ca4fb1d0-d899-4ef4-b825-0b7d02c708bd",
+                      "aws_account_id": "xxxxxxxxxxxxxx",
                       "creation_date": "2020-08-26T10:33:52Z",
                       "customer_master_key_spec": "SYMMETRIC_DEFAULT",
                       "deletion_date": null,
@@ -1837,7 +1837,7 @@
               ],
               "variables": {
                 "arn": {
-                  "default": "arn:aws:kms:us-east-1:670025224396:key/ca4fb1d0-d899-4ef4-b825-0b7d02c70var"
+                  "default": "arn:aws:kms:us-east-1:xxxxxxxxxxxxxx:key/ca4fb1d0-d899-4ef4-b825-0b7d02c70var"
                 }
               }
             }

--- a/aws/enforce_kms_key_names.rego
+++ b/aws/enforce_kms_key_names.rego
@@ -1,0 +1,170 @@
+# Validate that the KMS key name(alias) is in the allowed list
+#
+# To enforce this the policy must check that all uses of KMS keys a referenced from a data source and the data source itself uses and allowed key name.
+
+# KMS is used in many AWS services. This policy will attempt to deal with all cases
+
+# AWS CloudTrail : DONE
+# AWS Cloudwatch : DONE
+# Amazon DynamoDB : DONE
+# Amazon Elastic Block Store (Amazon EBS) : DONE
+# Amazon Elastic Transcoder : DONE
+# Amazon EMR : DONE
+# Amazon Redshift : DONE
+# Amazon Relational Database Service (Amazon RDS) : DONE
+# AWS Secrets Manager : DONE
+# Amazon Simple Email Service (Amazon SES) : DONE
+# Amazon Simple Storage Service (Amazon S3) : DONE
+# AWS Systems Manager Parameter Store : DONE
+
+
+package terraform
+
+import input.tfplan as tfplan
+import input.tfrun as tfrun
+
+allowed_kms_keys = [
+  "pg-kms-key"
+]
+
+contains(arr, elem) {
+  arr[_] = elem
+}
+
+# Configuration may be specified in one of 3 ways
+# - Constant value, i.e. a quoted string "the_value"
+# - A variable in the references[] specifying a value
+# - An actual reference e.g. data.foo.bar
+#
+# This extracts the relevant value, i.e. the constant value, the value of the variable or the reference
+eval_expression(plan, expr) = constant_value {
+    constant_value := expr.constant_value
+} else = var_value {
+    ref = expr.references[0]
+    startswith(ref, "var.")
+    var_name := replace(ref, "var.", "")
+    var_value := plan.variables[var_name].value
+} else = reference {
+    reference = expr.references[_]
+}
+
+#--------------------
+
+# Tests that the key_id used in the data source is in the allowed list.
+deny[reason] {
+  tfrun.is_destroy == false
+  walk(tfplan.configuration.root_module, [path, value])
+  value.mode == "data"
+  value.type == "aws_kms_key"
+  key_alias := eval_expression(tfplan, value.expressions.key_id)
+  key_name := trim_prefix(key_alias, "alias/")
+  not contains(allowed_kms_keys, key_name)
+  reason := sprintf("%s.%s :: KMS key name '%s' not in permitted list",[value.type,value.name, key_alias])
+}
+
+#---------------
+# S3 Buckets
+# Tests for a replication configuration rule referencing a KMS key. This MUST be a data source.
+deny[reason] {
+  tfrun.is_destroy == false
+  walk(tfplan.configuration.root_module, [path, value])
+  value.mode == "managed"
+  value.type == "aws_s3_bucket"
+  kms_key := eval_expression(tfplan, value.expressions.replication_configuration[_].rules[_].destination[_].replica_kms_key_id)
+  not startswith(kms_key, "data.aws_kms_key.")
+  reason := sprintf("%s.%s :: replication KMS Master key ID '%s' not derived from data source!",[value.type,value.name,kms_key])
+}
+
+# Tests for a server side encryption rule referencing a KMS key. This MUST be a data source.
+deny[reason] {
+  tfrun.is_destroy == false
+  walk(tfplan.configuration.root_module, [path, value])
+  value.mode == "managed"
+  value.type == "aws_s3_bucket"
+  kms_key := eval_expression(tfplan, value.expressions.server_side_encryption_configuration[_].rule[_].apply_server_side_encryption_by_default[_].kms_master_key_id)
+  not startswith(kms_key, "data.aws_kms_key.")
+  reason := sprintf("%s.%s :: server_side_encryption KMS Master key ID '%s' not derived from data source!",[value.type,value.name,kms_key])
+}
+
+#---------------
+# GENERAL
+# Search for attributes in the list and check they are referencing data sources
+
+attributes = [
+  "aws_ebs_volume:kms_key_id",
+  "aws_ebs_default_kms_key:key_arn",
+  "aws_db_instance:kms_key_id",
+  "aws_db_instance:performance_insights_kms_key_id",
+  "aws_rds_cluster:kms_key_id",
+  "aws_rds_cluster_instance:performance_insights_kms_key_id",
+  "aws_cloudtrail:kms_key_id",
+  "aws_cloudwatch_log_group:kms_key_id",
+  "aws_dynamodb_table:kms_key_arn",
+  "aws_elastictranscoder_pipeline:aws_kms_key_arn",
+  "aws_redshift_cluster:kms_key_id",
+  "aws_redshift_snapshot_copy_grant:kms_key_id",
+  "aws_secretsmanager_secret:kms_key_id",
+  "aws_ssm_parameter:key_id"
+]
+
+deny[reason] {
+  tfrun.is_destroy == false
+  walk(tfplan.configuration.root_module, [path, value])
+  attr := attributes[_]
+  attr_s := split(attr,":")
+  value.mode == "managed"
+  value.type == attr_s[0]
+  obj := json.filter(value.expressions,[attr_s[1]])
+  walk(obj, [opath, ovalue])
+  kms_key := eval_expression(tfplan, ovalue)
+  not startswith(kms_key, "data.aws_kms_key.")
+  reason := sprintf("%s.%s :: %s '%s' not derived from data source!",[value.type,value.name,attr_s[1],kms_key])
+}
+
+#---------
+# EMR
+
+# Extract ARN from the JSON config. This may be a UUID or alias/name arn.
+
+deny[reason] {
+  tfrun.is_destroy == false
+  walk(tfplan.configuration.root_module, [path, value])
+  value.mode == "managed"
+  value.type == "aws_emr_security_configuration"
+  config := eval_expression(tfplan, value.expressions.configuration)
+  arn := regex.find_n("arn:aws:kms:[a-z0-9-:/_]*", config, 1)
+  arn_bits := split(arn[0],":")
+  id := arn_bits[count(arn_bits)-1]
+  key_name := trim_prefix(id, "alias/")
+  not contains(allowed_kms_keys, key_name)
+  reason := sprintf("%s.%s :: configuration disc encryption key '%s' not from permitted list",[value.type,value.name,key_name])
+}
+
+#-----
+# SES
+
+# Tests for a S3 encryption referencing a KMS key. This MUST be a data source.
+deny[reason] {
+  tfrun.is_destroy == false
+  walk(tfplan.configuration.root_module, [path, value])
+  value.mode == "managed"
+  value.type == "aws_ses_receipt_rule"
+  kms_key := eval_expression(tfplan, value.expressions.s3_action.kms_key_arn)
+  not startswith(kms_key, "data.aws_kms_key.")
+  reason := sprintf("%s.%s :: s3_action KMS Master key ID '%s' not derived from data source!",[value.type,value.name,kms_key])
+}
+
+#------
+# SSM
+
+# Tests for a S3 encryption referencing a KMS key. This MUST be a data source.
+deny[reason] {
+  tfrun.is_destroy == false
+  walk(tfplan.configuration.root_module, [path, value])
+  value.mode == "managed"
+  value.type == "aws_ssm_resource_data_sync"
+  kms_key := eval_expression(tfplan, value.expressions.s3_destination.kms_key_arn)
+  not startswith(kms_key, "data.aws_kms_key.")
+  reason := sprintf("%s.%s :: s3_action KMS Master key ID '%s' not derived from data source!",[value.type,value.name,kms_key])
+}
+

--- a/aws/enforce_kms_key_names.rego
+++ b/aws/enforce_kms_key_names.rego
@@ -24,7 +24,7 @@ import input.tfplan as tfplan
 import input.tfrun as tfrun
 
 allowed_kms_keys = [
-  "pg-kms-keyx"
+  "pg-kms-key"
 ]
 
 contains(arr, elem) {

--- a/aws/enforce_kms_key_names.test.rego
+++ b/aws/enforce_kms_key_names.test.rego
@@ -2,7 +2,7 @@ package terraform
 
 test_s3_invalid {
     result = deny with input as data.mock.s3_invalid
-    count(result) == 0
+    count(result) > 0
 }
 
 test_s3_valid {
@@ -11,12 +11,12 @@ test_s3_valid {
 }
 
 
-test_s3_invalid {
+test_ebs_invalid {
     result = deny with input as data.mock.ebs_invalid
-    count(result) == 0
+    count(result) > 0
 }
 
-test_s3_valid {
+test_ebs_valid {
     result = deny with input as data.mock.ebs_valid
     count(result) == 0
 }

--- a/aws/enforce_kms_key_names.test.rego
+++ b/aws/enforce_kms_key_names.test.rego
@@ -1,0 +1,22 @@
+package terraform
+
+test_s3_invalid {
+    result = deny with input as data.mock.s3_invalid
+    count(result) == 0
+}
+
+test_s3_valid {
+    result = deny with input as data.mock.s3_valid
+    count(result) == 0
+}
+
+
+test_s3_invalid {
+    result = deny with input as data.mock.ebs_invalid
+    count(result) == 0
+}
+
+test_s3_valid {
+    result = deny with input as data.mock.ebs_valid
+    count(result) == 0
+}


### PR DESCRIPTION
@maratkomarov 

Policy to validate KMS keys names as requested by a customer. Their ask is

> Enforce a list of KMS keys to be used for encryption. If this could be done with the human name for the key that would be best, not the ugly UPN thing or the full ARN. For example with have a KMS CMK in each account called default-kms-key.

In KMS the name is actually an alias in the format "alias/name".

All AWS resources that use KMS require an ARN or ID and wont take a name in the simple "alias/name" format. So to enforce valid names the policy does two things.

1. Ensures that all kms key arguments use a data sources (data.aws_kms_key) to reference the ARN.
2. The alias/name used in any data.aws_kms_key is in the allowed list.

Most of these are simple top level attributes (standard) catered for in a single deny[] block driven by an array of attributes, but there are some odd ones that need their own processing.

Mocks test S3 (and odd one) and EBS (a standard one).